### PR TITLE
potentially fix error message for borg 1.2.x

### DIFF
--- a/tests/test-cases.nt
+++ b/tests/test-cases.nt
@@ -1089,9 +1089,7 @@ emborg with configs:
 
     cleanser:
         args: --config test7 list
-        expected:
-            > emborg error: list:
-            >     Repository /⟪EMBORG⟫/tests/repositories does not exist.
+        expected: emborg error: list: Repository /⟪EMBORG⟫/tests/repositories does not exist.
         expected_type: error
 
     harlequin:


### PR DESCRIPTION
When packaging emborg for [nixpkgs](https://github.com/NixOS/nixpkgs), I was attempting to get the tests running from within that context to verify that the resulting setup and all dependencies were working as expected. This test appears to be expecting explicit newlines and other whitespace, when it appears to all be on the same line for version 1.2.x of borgbackup (not sure if this is a difference in borgbackup or something else). I would love to see if the GitHub actions tests pass with this change or if it is a breaking change in formatting on borgbackup