### PR TITLE
fix tests on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tests/.local
 tests/configs
 tests/home
 tests/Users
+tests/Library
 .bump.cfg.nt
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tests/.config
 tests/.local
 tests/configs
 tests/home
+tests/Users
 .bump.cfg.nt
 
 # C extensions

--- a/emborg/preferences.py
+++ b/emborg/preferences.py
@@ -20,6 +20,7 @@
 from .shlib import to_path
 from appdirs import user_config_dir, user_data_dir
 from inform import dedent
+import os
 
 # Preferences {{{1
 # Constants {{{2
@@ -38,6 +39,10 @@ if config_dir.exists():
 else:
     CONFIG_DIR = user_config_dir(PROGRAM_NAME)
 DATA_DIR = user_data_dir(PROGRAM_NAME)
+if os.getenv("EMBORG_TEST", "") == "1":
+    # As a simplification, always use the Linux directories in tests.
+    CONFIG_DIR = str(to_path("~/.config/emborg"))
+    DATA_DIR = str(to_path("~/.local/share/emborg"))
 
 SETTINGS_FILE = "settings"
 OVERDUE_FILE = "overdue.conf"

--- a/emborg/preferences.py
+++ b/emborg/preferences.py
@@ -20,7 +20,6 @@
 from .shlib import to_path
 from appdirs import user_config_dir, user_data_dir
 from inform import dedent
-import os
 
 # Preferences {{{1
 # Constants {{{2

--- a/emborg/preferences.py
+++ b/emborg/preferences.py
@@ -39,10 +39,6 @@ if config_dir.exists():
 else:
     CONFIG_DIR = user_config_dir(PROGRAM_NAME)
 DATA_DIR = user_data_dir(PROGRAM_NAME)
-if os.getenv("EMBORG_TEST", "") == "1":
-    # As a simplification, always use the Linux directories in tests.
-    CONFIG_DIR = str(to_path("~/.config/emborg"))
-    DATA_DIR = str(to_path("~/.local/share/emborg"))
 
 SETTINGS_FILE = "settings"
 OVERDUE_FILE = "overdue.conf"

--- a/tests/STARTING_CONFIGS/overdue.conf
+++ b/tests/STARTING_CONFIGS/overdue.conf
@@ -1,7 +1,7 @@
 default_maintainer = 'nobody@nowhere.com'
 dumper = 'nobody@nowhere.com'
 default_max_age = 36 # hours
-root = '~/.local/share/emborg'
+root = '⟪DATA_DIR⟫/emborg'
 status_message = "{host}: {hours:0.1f} hours"
 repositories = [
     dict(host='test0', path='test0.latest.nt', max_age=0.2),

--- a/tests/test-cases.nt
+++ b/tests/test-cases.nt
@@ -4,7 +4,7 @@ emborg without configs:
         args: version
         expected: emborg version: \d+\.\d+(\.\d+(\.?\w+\d+)?)? \(\d\d\d\d-\d\d-\d\d\) \[Python \d\.\d+\.\d+\]\.
         expected_type: regex
-        remove: .config
+        remove: ⟪CONFIG_DIR⟫
 
     suburb:
         args: help
@@ -182,14 +182,14 @@ emborg without configs:
     labor:
         args:
         expected:
-            > Configuration directory created: /⟪EMBORG⟫/tests/.config/emborg.
+            > Configuration directory created: /⟪EMBORG⟫/tests/⟪CONFIG_DIR⟫/emborg.
             > Includes example settings files. Edit them to suit your needs.
             > Search for and replace any fields delimited with ⟪ and ⟫.
             > Delete any configurations you do not need.
             > Generally you will use either home or root, but not both.
 
     jerkin:
-        remove: .config
+        remove: ⟪CONFIG_DIR⟫
 
 
 emborg with configs:
@@ -348,7 +348,7 @@ emborg with configs:
             >                          'test0-{now}'
             >      check_after_create: True
             >                cmd_name: 'settings'
-            >              config_dir: '/⟪EMBORG⟫/tests/.config/emborg'
+            >              config_dir: '/⟪EMBORG⟫/tests/⟪CONFIG_DIR⟫/emborg'
             >             config_name: 'test0'
             >          configurations: """
             >                              test0 test1 test2 test3 test4 test5 test6 test7 test8 test9
@@ -367,7 +367,7 @@ emborg with configs:
             >                          'test0-*'
             >                home_dir: '/⟪EMBORG⟫/tests'
             >             keep_within: '1d'
-            >                 log_dir: '/⟪EMBORG⟫/tests/.local/share/emborg'
+            >                 log_dir: '/⟪EMBORG⟫/tests/⟪DATA_DIR⟫/emborg'
             >      prune_after_create: True
             >              repository: '~/repositories'
             >        run_after_backup: """
@@ -613,8 +613,8 @@ emborg with configs:
             >               config: test0
             >                roots: /⟪EMBORG⟫/tests/configs
             >          destination: /⟪EMBORG⟫/tests/repositories
-            >   settings directory: /⟪EMBORG⟫/tests/.config/emborg
-            >              logfile: /⟪EMBORG⟫/tests/.local/share/emborg/test0.log
+            >   settings directory: /⟪EMBORG⟫/tests/⟪CONFIG_DIR⟫/emborg
+            >              logfile: /⟪EMBORG⟫/tests/⟪DATA_DIR⟫/emborg/test0.log
             >      create last run: .*
             >       prune last run: .*
             >       check last run: .*

--- a/tests/test_emborg.py
+++ b/tests/test_emborg.py
@@ -25,7 +25,7 @@ from functools import partial
 import pytest
 import re
 from inform import is_str, Color, Error, dedent, indent
-from shlib import Run, cd, cp, cwd, ln, lsf, mkdir, rm, set_prefs, to_path, touch
+from shlib import Run, cd, cp, ln, lsf, mkdir, rm, set_prefs, to_path, touch
 from voluptuous import Schema, Optional, Required, Any
 
 

--- a/tests/test_emborg.py
+++ b/tests/test_emborg.py
@@ -192,6 +192,7 @@ def initialize(dependency_options):
         ln("~/.local/lib", ".local/lib")
         ln("configs", "configs.symlink")
         os.environ["HOME"] = str(cwd())
+        os.environ["EMBORG_TEST"] = "1"
     return dependency_options
 
 # initialize_configs fixture {{{3


### PR DESCRIPTION
Hello! I noticed that some of the tests are failing on macOS. I implemented a small fix. Happy to take feedback on it.

Details below.

---


The tests assume that the config dir is ~/.config and the data dir is ~/.local/share. Neither is true on macOS, and this causes several tests to fail:

	FAILED tests/test_emborg.py::test_emborg_without_configs[4] - AssertionError: Test ‘labor’ fails.
	FAILED tests/test_emborg.py::test_emborg_with_configs[5] - AssertionError: Test ‘periphery’ fails.
	FAILED tests/test_emborg.py::test_emborg_with_configs[25] - AssertionError: Test ‘build’ fails.
	FAILED tests/test_emborg.py::test_emborg_overdue[1] - AssertionError: Test ‘predator’ fails.
	FAILED tests/test_emborg.py::test_emborg_overdue[2] - AssertionError: Test ‘smelt’ fails.

Rather than changing the tests to dynamically use different test paths based on the OS[1], it's simpler to change emborg's behavior at test time to always use the Linux paths. That is what this change does.

Also adds tests/Users to .gitignore, which is the macOS equivalent of tests/home.

[1] This was in fact the first thing I tried. But as I got into it the added complexity didn't seem justified.